### PR TITLE
Add / on  CREDIT_CARD_INVOICE

### DIFF
--- a/organizze_client/_client.py
+++ b/organizze_client/_client.py
@@ -22,7 +22,7 @@ class OrganizzeClient:
     CREDIT_CARDS = 'credit_cards/'
     CREDIT_CARD = CREDIT_CARDS + '{credit_card_id}/'
     CREDIT_CARD_INVOICES = CREDIT_CARD + 'invoices'
-    CREDIT_CARD_INVOICE = CREDIT_CARD_INVOICES + '{invoice_id}/'
+    CREDIT_CARD_INVOICE = CREDIT_CARD_INVOICES + '/{invoice_id}/'
     CREDIT_CARD_INVOICE_PAYMENTS = CREDIT_CARD_INVOICE + 'payments'
     # Transactions
     TRANSACTIONS = 'transactions/'


### PR DESCRIPTION
Pela lógica atual a `get_credit_card_invoice` concatena o id da invoice **sem** o `/`  retornando um erro

```
credit_cards/{credit_card_id}/invoices{invoice_id}/
https://api.organizze.com.br/rest/v2/credit_cards/<credit_card_id>/invoices<invoice_id>/
```

Pela documentação da [API](https://github.com/organizze/api-doc#request-18) basta adicionar um `/` no  CREDIT_CARD_INVOICE